### PR TITLE
Add support for custom properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ node_modules
 
 # OS specific files
 .DS_Store
-results.json
+debug.json
 test/package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,6 +589,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
+    },
     "log-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "colors": "1.1.2",
     "js-yaml": "3.8.4",
     "lighthouse": "1.6.3",
+    "lodash.kebabcase": "4.1.1",
     "pkg-dir": "2.0.0",
     "prettycli": "1.3.0",
     "statistics": "3.3.0",

--- a/src/config.json
+++ b/src/config.json
@@ -14,6 +14,7 @@
     "first-meaningful-paint",
     "speed-index-metric",
     "time-to-interactive",
-    "byte-efficiency/total-byte-weight"
+    "byte-efficiency/total-byte-weight",
+    "user-timings"
   ]
 }

--- a/src/properties.js
+++ b/src/properties.js
@@ -5,11 +5,15 @@ const optimalValues = {
   'total-byte-weight': 1600
 }
 
-const units = {
-  'first-meaningful-paint': 'ms',
-  'speed-index-metric': '',
-  'time-to-interactive': 'ms',
-  'total-byte-weight': 'Kb'
+const units = property => {
+  return (
+    {
+      'first-meaningful-paint': 'ms',
+      'speed-index-metric': '',
+      'time-to-interactive': 'ms',
+      'total-byte-weight': 'Kb'
+    }[property] || 'ms'
+  )
 }
 
 module.exports = { optimalValues, units }

--- a/test/.perf.yml
+++ b/test/.perf.yml
@@ -3,3 +3,4 @@ fail: false
 url: http://localhost:3000/page.html
 thresholds:
   - time-to-interactive: 500
+  - page-ready: 1500

--- a/test/page.html
+++ b/test/page.html
@@ -46,5 +46,6 @@
   domain in examples without prior coordination or asking for permission.</p>
   <p><a href="http://www.iana.org/domains/example">More information...</a></p>
 </div>
+<script>performance.mark('Page ready')</script>
 </body>
 </html>


### PR DESCRIPTION
Send a user timing performance event.
```js
performance.mark('Page ready')
```

And add the kebabcased key to `.perf.yml`

```yaml
thresholds:
  - page-ready: 1500
```