### PR TITLE
Add a 100ms threshold for comparison with master

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -21,7 +21,7 @@ if (token && sha) {
 
   pass = values => {
     /* default message */
-    let message = 'Performance checks passed!'
+    let message = 'Good Job! Performance checks passed!'
 
     if (store.enabled) {
       const master = store.get()
@@ -45,7 +45,13 @@ if (token && sha) {
       const verb = increased ? 'increased' : 'improved'
       const difference = Math.round(Math.abs(values[key] - master[key]))
 
-      message = `${starter} ${startcase(key)} has ${verb} by ${difference} ${units(key)}`
+      /*
+        Show diff in build if it is at least 100ms,
+        anything below that is not reliable
+      */
+      if (difference >= 100) {
+        message = `${starter} ${startcase(key)} has ${verb} by ${difference} ${units(key)}`
+      }
     }
 
     build.pass(message)


### PR DESCRIPTION
Comparison with masters should have some actionable insights. Difference < 100ms are inconclusive.

Idea for future: Store standard deviation along with average and use that to make a better decision.